### PR TITLE
Typo fixes

### DIFF
--- a/content/docs/error-handling.md
+++ b/content/docs/error-handling.md
@@ -52,7 +52,7 @@ await url.WithTimeout(TimeSpan.FromMinutes(10)).GetAsync();
 
 ### Allowing Non-2XX Responses
 
-If you don't like the default throwing behavior, you can change it at [any settings level](configuration) via `Settings.AllowedHttpStatusRange`. This is a string based setting that excepts wildcards, so if you never want to throw, set it to `*`.
+If you don't like the default throwing behavior, you can change it at [any settings level](configuration) via `Settings.AllowedHttpStatusRange`. This is a string based setting that accepts wildcards, so if you never want to throw, set it to `*`.
 
 You can also allow non-2XX at the request level:
 

--- a/content/index.md
+++ b/content/index.md
@@ -50,7 +50,7 @@ using (var httpTest = new HttpTest()) {
 
 <div class="col-md-4"><div class="well">
 <h3><i class="fa fa-stack-overflow"></i> Ask a Question</h3>
-<p>For programming question related to Flurl, please <a href="http://stackoverflow.com/questions/ask?tags=flurl">ask</a> on Stack Overflow.</p>
+<p>For programming questions related to Flurl, please <a href="http://stackoverflow.com/questions/ask?tags=flurl">ask</a> on Stack Overflow.</p>
 </div></div>
 
 <div class="col-md-4"><div class="well">
@@ -65,5 +65,5 @@ using (var httpTest = new HttpTest()) {
 
 <div class="col-md-4"><div class="well">
 <h3><i class="fa fa-code-fork"></i> Contribute</h3>
-<p>To contribure code, please see the <a href="https://github.com/tmenier/Flurl/wiki/Contribution-Guidelines">contribution guidelines</a>.</p>
+<p>To contribute code, please see the <a href="https://github.com/tmenier/Flurl/wiki/Contribution-Guidelines">contribution guidelines</a>.</p>
 </div></div>


### PR DESCRIPTION
A couple of super minor typo/grammatical updates for the docs

I'd also like to make the suggestion that on the `ask a question on stackoverflow` sentence, maybe it would display better to have the `stack overflow` the highlight/link text rather than `ask`