### PR TITLE
Fix typo

### DIFF
--- a/content/docs/client-lifetime.md
+++ b/content/docs/client-lifetime.md
@@ -10,7 +10,7 @@ Flurl.Http adheres to this guidance by default. Fluent methods like this will cr
 var data = await "http://api.com/endpoint".GetJsonAsync();
 ```
 
-_* As of 3.0, scheme are port are also part of the cache key. So for example, if you are hitting both http and https endpoints of the same host, you'll have 2 client instances that can be configured independently._
+_* As of 3.0, scheme and port are also part of the cache key. So for example, if you are hitting both http and https endpoints of the same host, you'll have 2 client instances that can be configured independently._
 
 ### Managing Instances Explicitly
 


### PR DESCRIPTION
Small typo on the `Lifetime Management` page.